### PR TITLE
Corrects template location documentation, adds to README.md

### DIFF
--- a/Command/CrudGeneratorCommand.php
+++ b/Command/CrudGeneratorCommand.php
@@ -81,13 +81,13 @@ Using the --template option allows to set base template from which the crud view
 
 Every generated file is based on a template. There are default templates but they can be overridden by placing custom templates in one of the following locations, by order of priority:
 
-<info>BUNDLE_PATH/Resources/CrudGeneratorBundle/skeleton/crud
-APP_PATH/Resources/CrudGeneratorBundle/skeleton/crud</info>
+<info>BUNDLE_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/crud
+APP_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/crud</info>
 
 And
 
-<info>__bundle_path__/Resources/CrudGeneratorBundle/skeleton/form
-__project_root__/app/Resources/CrudGeneratorBundle/skeleton/form</info>
+<info>BUNDLE_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/form
+APP_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/form</info>
 
 EOT
         );

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ The bundle adds few new parameters compared to the doctrine crud generator, to c
 
 Don't forget, that this is a just crud generator and you are free to change everything generated from this bundle. 
 
+
+### Templates
+
+Every generated file is based on a template. There are default templates but they can be overridden by placing custom templates in one of the following locations, by order of priority:
+
+    BUNDLE_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/crud
+    APP_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/crud
+
+And
+
+    BUNDLE_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/form
+    APP_PATH/Resources/PetkoparaCrudGeneratorBundle/skeleton/form
+
 ## Author
 
 Petko Petkov - petkopara at gmail dot com


### PR DESCRIPTION
Fixes the alternate template location paths in the command help output. Copies the template information section into the main README.md document.

The ability to use custom templates in this generator is an excellent feature, but I didn't realize it existed for quite a while. When I did finally notice that section in the command's help output, I was stymied a bit because the documented folder location was slightly wrong. This pull request is to correct that folder location info, and to make the information more accessible (copied into the README.md) so others will find it more easily.

I'm an experienced programmer but a newbie to the Github pull request workflow, so let me know if there are things I should do differently to make this more acceptable or easier for you to review. I have several more pull requests coming shortly.