### PR TITLE
Adds new _title_ parameter to the th_sortable macro.

### DIFF
--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -52,7 +52,7 @@
 {% if without_sorting == false %}
                 {{'{% import "PetkoparaCrudGeneratorBundle::macros/th_sortable.html.twig" as macros %}'}}
     {% for field, metadata in fields %}
-                        <th>{{"{{macros.th_sortable('" ~field~"',app.request.get('pcg_sort_col'), app.request.get('pcg_sort_order') , '" ~ route_name_prefix ~ "')}}"}}</th>
+                        <th>{{"{{macros.th_sortable('" ~field~"',app.request.get('pcg_sort_col'), app.request.get('pcg_sort_order') , '" ~ route_name_prefix ~ "', '" ~ field|capitalize ~ "')}}" }}</th>
     {% endfor %}
 {% else %}
     {% for field, metadata in fields %}

--- a/Resources/views/macros/th_sortable.html.twig
+++ b/Resources/views/macros/th_sortable.html.twig
@@ -1,14 +1,14 @@
 
-{% macro th_sortable(colName, sortColumn, sortOrder, route) %}
+{% macro th_sortable(colName, sortColumn, sortOrder, route, title) %}
     {% set iconDirection = sortOrder=='asc'?'down':'up' %}
     {% set nextSortOrder = sortOrder=='asc'?'desc':'asc'%}
     {% if colName == sortColumn %}
         <a href="{{path(route ,app.request.query.all|merge({'pcg_sort_col': colName, 'pcg_sort_order': nextSortOrder})) }}">
-            {{colName|capitalize}} <span class="glyphicon glyphicon-arrow-{{ iconDirection }}" aria-hidden="true"></span>
+            {{title ?? colName|capitalize}} <span class="glyphicon glyphicon-arrow-{{ iconDirection }}" aria-hidden="true"></span>
         </a>
     {% else %}
         <a href="{{path(route ,app.request.query.all|merge({'pcg_sort_col': colName, 'pcg_sort_order':'asc'}) )}}">
-            {{colName|capitalize}}
+            {{title ?? colName|capitalize}}
         </a>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Column titles in the index page table can now be set to any arbitrary value, not just the entity's field name.

This change alters the th_sortable.html.twig macro by adding an optional 5th parameter "title". If title is set, it will be used for the column header text in sortable columns. If unset, the macro will use the colName parameter (capitalized), which was the original macro behavior.

Since the macro uses its original behavior if the 5th parameter is unset, it is safe to use this version of the macro with twig templates that were created with an older version of the generator.

The index.html.twig.twig generator template is altered to call the macro with all 5 parameters, The new title parameter is set to a capitalized version of the field name in the default generated index.html.twig. So unless the generated twig template is edited after generation, the resulting column labels are the same as they would have been before this change was merged. However now there is the option to edit the generated template to change the labels to something more desirable.