### PR TITLE
Humanize labels

### DIFF
--- a/DependencyInjection/PetkoparaCrudGeneratorExtension.php
+++ b/DependencyInjection/PetkoparaCrudGeneratorExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PetkoparaCrudGeneratorBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration.
+ *
+ * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
+ */
+class PetkoparaCrudGeneratorExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/DependencyInjection/PetkoparaCrudGeneratorExtension.php
+++ b/DependencyInjection/PetkoparaCrudGeneratorExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PetkoparaCrudGeneratorBundle\DependencyInjection;
+namespace Petkopara\CrudGeneratorBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;

--- a/Generator/PetkoparaCrudGenerator.php
+++ b/Generator/PetkoparaCrudGenerator.php
@@ -5,9 +5,11 @@ namespace Petkopara\CrudGeneratorBundle\Generator;
 use Doctrine\Common\Util\Inflector;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Petkopara\CrudGeneratorBundle\Configuration\Configuration;
+use Petkopara\CrudGeneratorBundle\Twig\CrudTemplateExtension;
 use RuntimeException;
 use Sensio\Bundle\GeneratorBundle\Generator\DoctrineCrudGenerator;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Twig_Loader_Filesystem;
 
 class PetkoparaCrudGenerator extends DoctrineCrudGenerator
 {
@@ -196,5 +198,16 @@ class PetkoparaCrudGenerator extends DoctrineCrudGenerator
 
         ));
     }
+
+    protected function getTwigEnvironment()
+    {
+        $twig = parent::getTwigEnvironment();
+        $twig->addExtension(new CrudTemplateExtension());
+        /** @var Twig_Loader_Filesystem $loader */
+        $loader = $twig->getLoader();
+        $loader->addPath(dirname(__DIR__) . '/Resources/views');
+        return $twig;
+    }
+
 
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,3 +2,7 @@ services:
 #    petkopara_crud.example:
 #        class: Petkopara\Bundle\CrudBundle\Example
 #        arguments: ["@service_id", "plain_value", %parameter%]
+    petkopara_crud.twig_extension:
+        class: PetkoparaCrudAssetsBundle\Twig\CrudTemplateExtension
+        tags:
+            - { name: twig.extension }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,6 @@ services:
 #        class: Petkopara\Bundle\CrudBundle\Example
 #        arguments: ["@service_id", "plain_value", %parameter%]
     petkopara_crud.twig_extension:
-        class: PetkoparaCrudAssetsBundle\Twig\CrudTemplateExtension
+        class: Petkopara\CrudGeneratorBundle\Twig\CrudTemplateExtension
         tags:
             - { name: twig.extension }

--- a/Resources/skeleton/crud/views/edit.html.twig.twig
+++ b/Resources/skeleton/crud/views/edit.html.twig.twig
@@ -1,14 +1,14 @@
 {{ "{% extends '"~  base_template  ~ "' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }}" }} -  Edit {{ entity_singularized }}
+{{ "{{ parent() }}" }} -  Edit {{ entity_singularized|humanize_uc }}
 {{ "{% endblock %}" }}
 
 {{ "{% block body %}" }}
 
 <div id="top" class="row">
     <div class="page-header">
-        <h2>Edit {{ entity_singularized }} <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></h2>
+        <h2>Edit {{ entity_singularized|humanize_lc }} <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></h2>
     </div>
 </div>
 

--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -1,7 +1,7 @@
 {{ "{% extends '"~  base_template  ~ "' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }}" }} - {{ entity_singularized }} index
+{{ "{{ parent() }}" }} - {{ entity_singularized|humanize_uc }} index
 {{ "{% endblock %}" }}
 
 {{ "{% block body %}" }}
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-12">
         <div class="page-header">
-            <h2><a href="{{ "{{ path('"~ route_name_prefix ~"') }}" }}">{{ entity|humanize }}</a></h2>
+            <h2><a href="{{ "{{ path('"~ route_name_prefix ~"') }}" }}">{{ entity|humanize_uc }}</a></h2>
         </div>
     </div>
         
@@ -56,7 +56,7 @@
     {% endfor %}
 {% else %}
     {% for field, metadata in fields %}
-                        <th>{{ field|capitalize }}</th>
+                        <th>{{ field|humanize_uc }}</th>
     {% endfor %}
 {% endif %}
 

--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-12">
         <div class="page-header">
-            <h2><a href="{{ "{{ path('"~ route_name_prefix ~"') }}" }}">{{ entity }}</a></h2>
+            <h2><a href="{{ "{{ path('"~ route_name_prefix ~"') }}" }}">{{ entity|humanize }}</a></h2>
         </div>
     </div>
         

--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -52,7 +52,7 @@
 {% if without_sorting == false %}
                 {{'{% import "PetkoparaCrudGeneratorBundle::macros/th_sortable.html.twig" as macros %}'}}
     {% for field, metadata in fields %}
-                        <th>{{"{{macros.th_sortable('" ~field~"',app.request.get('pcg_sort_col'), app.request.get('pcg_sort_order') , '" ~ route_name_prefix ~ "', '" ~ field|capitalize ~ "')}}" }}</th>
+                        <th>{{"{{macros.th_sortable('" ~field~"',app.request.get('pcg_sort_col'), app.request.get('pcg_sort_order') , '" ~ route_name_prefix ~ "', '" ~ field|humanize_uc ~ "')}}" }}</th>
     {% endfor %}
 {% else %}
     {% for field, metadata in fields %}

--- a/Resources/skeleton/crud/views/new.html.twig.twig
+++ b/Resources/skeleton/crud/views/new.html.twig.twig
@@ -1,14 +1,14 @@
 {{ "{% extends '"~  base_template  ~ "' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }}" }} - New {{ entity_singularized }}
+{{ "{{ parent() }}" }} - New {{ entity_singularized|humanize_lc }}
 {{ "{% endblock %}" }}
 
 {{ "{% block body %}" }}
 
 <div id="top" class="row">
     <div class="page-header">
-        <h2>New {{ entity_singularized }} <span class="glyphicon glyphicon-file" aria-hidden="true"></span> </h2>
+        <h2>New {{ entity_singularized|humanize_lc }} <span class="glyphicon glyphicon-file" aria-hidden="true"></span> </h2>
     </div>
 </div>
     

--- a/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/Resources/skeleton/crud/views/show.html.twig.twig
@@ -1,14 +1,14 @@
 {{ "{% extends '"~  base_template  ~ "' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }}" }} - {{ entity_singularized }}
+{{ "{{ parent() }}" }} - {{ entity_singularized|humanize_uc }}
 {{ "{% endblock %}" }}
 
 {{ "{% block body %}" }}
 
 <div id="top" class="row">
     <div class="page-header">
-        <h2>View {{ entity_singularized }} <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span> </h2>
+        <h2>View {{ entity_singularized|humanize_lc }} <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span> </h2>
     </div>
 </div>
 
@@ -17,7 +17,7 @@
     {%- for field, metadata in fields %}
 
     <div class="col-md-6">
-        <p><strong>{{ field|capitalize }}</strong></p>
+        <p><strong>{{ field|humanize_uc }}</strong></p>
         <p>
 {%if metadata.type in ['datetime','datetimetz'] %}
             {{ '{% if ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' %}{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}{% endif %}' }}

--- a/Resources/views/macros/th_sortable.html.twig
+++ b/Resources/views/macros/th_sortable.html.twig
@@ -4,11 +4,11 @@
     {% set nextSortOrder = sortOrder=='asc'?'desc':'asc'%}
     {% if colName == sortColumn %}
         <a href="{{path(route ,app.request.query.all|merge({'pcg_sort_col': colName, 'pcg_sort_order': nextSortOrder})) }}">
-            {{title ?? colName|capitalize}} <span class="glyphicon glyphicon-arrow-{{ iconDirection }}" aria-hidden="true"></span>
+            {{title ?? colName|humanize_uc}} <span class="glyphicon glyphicon-arrow-{{ iconDirection }}" aria-hidden="true"></span>
         </a>
     {% else %}
         <a href="{{path(route ,app.request.query.all|merge({'pcg_sort_col': colName, 'pcg_sort_order':'asc'}) )}}">
-            {{title ?? colName|capitalize}}
+            {{title ?? colName|humanize_uc}}
         </a>
     {% endif %}
 {% endmacro %}

--- a/Resources/views/macros/th_sortable.html.twig
+++ b/Resources/views/macros/th_sortable.html.twig
@@ -4,11 +4,11 @@
     {% set nextSortOrder = sortOrder=='asc'?'desc':'asc'%}
     {% if colName == sortColumn %}
         <a href="{{path(route ,app.request.query.all|merge({'pcg_sort_col': colName, 'pcg_sort_order': nextSortOrder})) }}">
-            {{colName|capitalize}} <span class="glyphicon glyphicon-arrow-{{ iconDirection }}" aria-hidden="true"></span>
+            {{colName|humanize_uc}} <span class="glyphicon glyphicon-arrow-{{ iconDirection }}" aria-hidden="true"></span>
         </a>
     {% else %}
         <a href="{{path(route ,app.request.query.all|merge({'pcg_sort_col': colName, 'pcg_sort_order':'asc'}) )}}">
-            {{colName|capitalize}}
+            {{colName|humanize_uc}}
         </a>
     {% endif %}
 {% endmacro %}

--- a/Twig/CrudTemplateExtension.php
+++ b/Twig/CrudTemplateExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PetkoparaCrudGeneratorBundle\Twig;
+namespace Petkopara\CrudGeneratorBundle\Twig;
 
 /**
  * Class CrudTemplateExtension

--- a/Twig/CrudTemplateExtension.php
+++ b/Twig/CrudTemplateExtension.php
@@ -2,14 +2,54 @@
 
 namespace PetkoparaCrudGeneratorBundle\Twig;
 
+/**
+ * Class CrudTemplateExtension
+ * @package PetkoparaCrudGeneratorBundle\Twig
+ *
+ * This class adds two Twig filters: "humanize_lc" and "humanize_uc". Both of them
+ * split camelCase and snake_case strings on their uppercase letters and "_" character,
+ * respectively, to form a more human readable sentence.
+ *
+ * The _lc variant returns all words in the sentence in lower case. The _uc variant
+ * makes all words in the sentence lowercase, except the first word which has its
+ * first letter uppercase.
+ *
+ */
 class CrudTemplateExtension extends \Twig_Extension
 {
 
     public function getFilters()
     {
         return array(
-            new \Twig_Filter('humanize', array('Symfony\Component\Form\FormRenderer', 'humanize')),
+            new \Twig_SimpleFilter('humanize_lc', array($this, 'humanize_lc')),
+            new \Twig_SimpleFilter('humanize_uc', array($this, 'humanize_uc'))
         );
+    }
+
+    /**
+     * Splits the incoming $text string on all uppercase letters and "_" characters,
+     * and returns the resulting words as a sentence. All words in the output sentence
+     * are lowercase.
+     *
+     * @param string $text
+     * @return string
+     */
+    public function humanize_lc($text)
+    {
+        return strtolower(trim(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $text)));
+    }
+
+    /**
+     * Splits the incoming $text string on all uppercase letters and "_" characters,
+     * and returns the resulting words as a sentence. The first character of the first
+     * word is set to uppercase, all other letters are set to lowercase.
+     *
+     * @param string $text
+     * @return string
+     */
+    public function humanize_uc($text)
+    {
+        return ucfirst($this->humanize_lc($text));
     }
 
 }

--- a/Twig/CrudTemplateExtension.php
+++ b/Twig/CrudTemplateExtension.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PetkoparaCrudGeneratorBundle\Twig;
+
+class CrudTemplateExtension extends \Twig_Extension
+{
+
+    public function getFilters()
+    {
+        return array(
+            new \Twig_Filter('humanize', array('Symfony\Component\Form\FormRenderer', 'humanize')),
+        );
+    }
+
+}


### PR DESCRIPTION
This adds two custom filters to the twig environment used by the CRUD generator: "humanize_lc" and "humanize_uc". Both are near clones of the "humanize" filter provided by the symfony/twig-bridge. Both filters split camelCase and snake_case text strings into individual words, broken on each capital letter and "_" character. The _lc variant leaves all words lowercase. The _uc variant capitalizes the first letter of the first word. (I did not simply include the symfony/twig-bridge package because it introduced composer conflicts I could not resolve.)

With these two new filters available, the generator templates and the th_sortable macro have been altered to use them to split the entity name and field labels into more readable words.

(The title override in th_sortable remains, and that override is *not* run through any filter inside the macro. So users can change the index page column labels back to camelCase or snake_case if they desire, just by manually setting the titles that way after generation. And of course the entity names in page titles and headlines can still be manually changed after generation. This change just makes the default arguably more readable.