### PR TITLE
Fix issue with PostgreSQL

### DIFF
--- a/Resources/skeleton/crud/actions/index.php.twig
+++ b/Resources/skeleton/crud/actions/index.php.twig
@@ -15,10 +15,9 @@
 {% if filter_type != constant('Petkopara\\CrudGeneratorBundle\\Command\\CrudGeneratorCommand::FILTER_TYPE_NONE') %}
         list($filterForm, $queryBuilder) = $this->filter($queryBuilder, $request);
 {% endif %}
+        $totalOfRecordsString = $this->getTotalOfRecordsString(clone $queryBuilder, $request);
         list(${{ entity_pluralized }}, $pagerHtml) = $this->paginator($queryBuilder, $request);
         
-        $totalOfRecordsString = $this->getTotalOfRecordsString($queryBuilder, $request);
-
 {% if bundle_views == false%}
         return $this->render('{{ entity|lower|replace({'\\': '/'}) }}/index.html.twig', array(
 {%else%}


### PR DESCRIPTION
This patch fixes the "Grouping error" that occurs on the index page when using PostgreSQL.

This error was due to the fact that when using COUNT and ORDER BY, pgSQL requires all the fields in ORDER BY clause to also appear in GROUP BY clause, so the COUNT request used to get the total number of items must be executed before adding the order parameters to the query builder.

Fixes issue #44